### PR TITLE
Fix/hiv cbhs workflow with reregistration

### DIFF
--- a/opensrp-chw-hf/build.gradle
+++ b/opensrp-chw-hf/build.gradle
@@ -264,7 +264,7 @@ flavors.each { productFlavorName ->
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation('org.smartregister:opensrp-client-chw-core:1.5.31.13-NACP-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-chw-core:1.5.31.16-NACP-SNAPSHOT@aar') {
 //    implementation(project(":opensrp-chw-core")) {
         transitive = true
         exclude group: 'com.android.support', module: 'appcompat-v7'

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/activity/FamilyOtherMemberProfileActivity.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/activity/FamilyOtherMemberProfileActivity.java
@@ -28,6 +28,7 @@ import org.smartregister.chw.hf.BuildConfig;
 import org.smartregister.chw.hf.HealthFacilityApplication;
 import org.smartregister.chw.hf.R;
 import org.smartregister.chw.hf.custom_view.FamilyMemberFloatingMenu;
+import org.smartregister.chw.hf.dao.HfHivDao;
 import org.smartregister.chw.hf.fragment.FamilyOtherMemberProfileFragment;
 import org.smartregister.chw.hf.presenter.FamilyOtherMemberActivityPresenter;
 import org.smartregister.chw.hf.utils.Constants;
@@ -262,7 +263,7 @@ public class FamilyOtherMemberProfileActivity extends CoreFamilyOtherMemberProfi
 
 
         if (BuildConfig.BUILD_FOR_BORESHA_AFYA_SOUTH) {
-            menu.findItem(R.id.action_hiv_registration).setVisible(!(HivDao.isRegisteredForHiv(baseEntityId) || HivIndexDao.isRegisteredIndex(baseEntityId)));
+            menu.findItem(R.id.action_hiv_registration).setVisible(!(HfHivDao.isHivMember(baseEntityId) || HivIndexDao.isRegisteredIndex(baseEntityId)));
         }
     }
 

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/dao/HfHivDao.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/dao/HfHivDao.java
@@ -1,0 +1,19 @@
+package org.smartregister.chw.hf.dao;
+
+import org.smartregister.dao.AbstractDao;
+
+import java.util.List;
+
+public class HfHivDao extends AbstractDao {
+    public static boolean isHivMember(String baseEntityId) {
+        String sql = "select count(*) count from ec_hiv_register where base_entity_id = '" + baseEntityId + "'" + " AND (UPPER (ec_hiv_register.client_hiv_status_after_testing) LIKE UPPER('Positive')) ";
+
+        DataMap<Integer> dataMap = cursor -> getCursorIntValue(cursor, "count");
+
+        List<Integer> res = readData(sql, dataMap);
+
+        if (res == null || res.size() < 1)
+            return false;
+        return res.get(0) == 1;
+    }
+}

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/AllClientsUtils.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/AllClientsUtils.java
@@ -33,6 +33,7 @@ import org.smartregister.chw.hf.activity.MalariaProfileActivity;
 import org.smartregister.chw.hf.activity.PncMemberProfileActivity;
 import org.smartregister.chw.hf.activity.TbProfileActivity;
 import org.smartregister.chw.hf.dao.FamilyDao;
+import org.smartregister.chw.hf.dao.HfHivDao;
 import org.smartregister.chw.hf.dao.HfHtsDao;
 import org.smartregister.chw.hf.model.FamilyDetailsModel;
 import org.smartregister.chw.hiv.dao.HivDao;
@@ -213,7 +214,7 @@ public class AllClientsUtils {
     }
 
     public static void updateHivMenuItems(String baseEntityId, Menu menu) {
-        if (HivDao.isRegisteredForHiv(baseEntityId)) {
+        if (HfHivDao.isHivMember(baseEntityId)) {
             menu.findItem(R.id.action_hiv_registration).setVisible(false);
         } else {
             menu.findItem(R.id.action_hiv_registration).setVisible(true);

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/HfQueryConstant.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/HfQueryConstant.java
@@ -46,7 +46,7 @@ public interface HfQueryConstant {
             "    FROM ec_hiv_index_hf\n" +
             "    UNION ALL\n" +
             "    SELECT ec_hiv_register.base_entity_id AS base_entity_id\n" +
-            "    FROM ec_hiv_register \n" +
+            "    FROM ec_hiv_register WHERE (UPPER (ec_hiv_register.client_hiv_status_after_testing) LIKE UPPER('Positive')) \n" +
             "    UNION ALL\n" +
             "    SELECT ec_hts_register.base_entity_id AS base_entity_id\n" +
             "    FROM ec_hts_register \n"+


### PR DESCRIPTION
This pull request fixes:
- [x] showing the client sent for HIV testing but found negative as an independent client in all clients
- [x] allows the client to reregister in case they tested negative in a previous testing