### PR TITLE
Fix/mother champion referral

### DIFF
--- a/opensrp-chw-hf/src/main/assets/json.form-sw/pmtct_community_followup_referral.json
+++ b/opensrp-chw-hf/src/main/assets/json.form-sw/pmtct_community_followup_referral.json
@@ -47,7 +47,7 @@
     "encounter_location": ""
   },
   "step1": {
-    "title": "Rufaa ya Ufuatiliaji wa PMTCT katika Ngazi ya Jamii",
+    "title": "Rufaa Kwa Mama Kinara",
     "fields": [
       {
         "key": "last_client_visit_date",

--- a/opensrp-chw-hf/src/main/assets/json.form-sw/pmtct_community_followup_referral.json
+++ b/opensrp-chw-hf/src/main/assets/json.form-sw/pmtct_community_followup_referral.json
@@ -94,6 +94,18 @@
         }
       },
       {
+        "key": "mother_champion_location",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "mother_champion_location",
+        "type": "spinner",
+        "hint": "Chagua Eneo la Mama Kinara",
+        "v_required": {
+          "value": true,
+          "err": "Tafadhali chagua eneo alipo mama kinara"
+        }
+      },
+      {
         "key": "comment_pmtct_community_followup",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw-hf/src/main/assets/json.form-sw/pmtct_community_followup_referral.json
+++ b/opensrp-chw-hf/src/main/assets/json.form-sw/pmtct_community_followup_referral.json
@@ -58,8 +58,6 @@
         "hint": "Tarehe ya mwisho mteja kuhudhulia Kituoni",
         "expanded": false,
         "max_date": "today",
-        "editable": false,
-        "read_only": true,
         "v_required": {
           "value": "true",
           "err": "Tafadhali bainisha Tarehe ya mwisho mteja kuhudhulia Kituoni"

--- a/opensrp-chw-hf/src/main/assets/json.form/pmtct_community_followup_referral.json
+++ b/opensrp-chw-hf/src/main/assets/json.form/pmtct_community_followup_referral.json
@@ -94,6 +94,18 @@
         }
       },
       {
+        "key": "mother_champion_location",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "mother_champion_location",
+        "type": "spinner",
+        "hint": "Mother Champion Location",
+        "v_required": {
+          "value": true,
+          "err": "Please enter the Mother Champion Location"
+        }
+      },
+      {
         "key": "comment_pmtct_community_followup",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw-hf/src/main/assets/json.form/pmtct_community_followup_referral.json
+++ b/opensrp-chw-hf/src/main/assets/json.form/pmtct_community_followup_referral.json
@@ -47,7 +47,7 @@
     "encounter_location": ""
   },
   "step1": {
-    "title": "PMTCT Community Followup Referral",
+    "title": "Mother Champion Referral",
     "fields": [
       {
         "key": "last_client_visit_date",

--- a/opensrp-chw-hf/src/main/assets/json.form/pmtct_community_followup_referral.json
+++ b/opensrp-chw-hf/src/main/assets/json.form/pmtct_community_followup_referral.json
@@ -58,8 +58,6 @@
         "hint": "Client's last facility visit date",
         "expanded": false,
         "max_date": "today",
-        "editable": false,
-        "read_only": true,
         "v_required": {
           "value": "true",
           "err": "Please specify the client's last facility visit date"

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/activity/PmtctProfileActivity.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/activity/PmtctProfileActivity.java
@@ -47,6 +47,7 @@ import org.smartregister.chw.pmtct.util.Constants;
 import org.smartregister.chw.referral.util.JsonFormConstants;
 import org.smartregister.clientandeventmodel.Event;
 import org.smartregister.commonregistry.CommonPersonObjectClient;
+import org.smartregister.dao.LocationsDao;
 import org.smartregister.domain.AlertStatus;
 import org.smartregister.family.contract.FamilyProfileContract;
 import org.smartregister.family.domain.FamilyEventClient;
@@ -58,6 +59,7 @@ import org.smartregister.opd.utils.OpdDbConstants;
 import org.smartregister.repository.AllSharedPreferences;
 
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -69,8 +71,12 @@ import androidx.annotation.RequiresApi;
 import androidx.recyclerview.widget.RecyclerView;
 import timber.log.Timber;
 
+import static org.smartregister.AllConstants.LocationConstants.SPECIAL_TAG_FOR_OPENMRS_TEAM_MEMBERS;
 import static org.smartregister.chw.core.utils.CoreConstants.EventType.PMTCT_COMMUNITY_FOLLOWUP;
 import static org.smartregister.chw.hf.utils.Constants.JsonFormConstants.STEP1;
+import static org.smartregister.chw.hf.utils.JsonFormUtils.METADATA;
+import static org.smartregister.chw.hf.utils.JsonFormUtils.SYNC_LOCATION_ID;
+import static org.smartregister.util.JsonFormUtils.ENCOUNTER_LOCATION;
 import static org.smartregister.util.JsonFormUtils.FIELDS;
 import static org.smartregister.util.JsonFormUtils.VALUE;
 
@@ -134,6 +140,10 @@ public class PmtctProfileActivity extends CorePmtctProfileActivity {
                 return true;
             } else if (itemId == R.id.action_issue_pmtct_followup_referral) {
                 JSONObject formJsonObject = (new FormUtils()).getFormJsonFromRepositoryOrAssets(this, CoreConstants.JSON_FORM.getPmtctcCommunityFollowupReferral());
+                //adds the chw locations under the current facility
+                JSONObject motherChampionLocationField = CoreJsonFormUtils.getJsonField(formJsonObject, org.smartregister.util.JsonFormUtils.STEP1, "mother_champion_location");
+                CoreJsonFormUtils.addLocationsToDropdownField(LocationsDao.getLocationsByTags(
+                        Collections.singleton(SPECIAL_TAG_FOR_OPENMRS_TEAM_MEMBERS)), motherChampionLocationField);
 
                 Date lastVisitDate;
                 if (followUpVisitDate != null) {

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/activity/PmtctProfileActivity.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/activity/PmtctProfileActivity.java
@@ -26,6 +26,7 @@ import org.smartregister.chw.core.custom_views.CorePmtctFloatingMenu;
 import org.smartregister.chw.core.listener.OnClickFloatingMenu;
 import org.smartregister.chw.core.rule.PmtctFollowUpRule;
 import org.smartregister.chw.core.utils.CoreConstants;
+import org.smartregister.chw.core.utils.CoreJsonFormUtils;
 import org.smartregister.chw.core.utils.FpUtil;
 import org.smartregister.chw.core.utils.HomeVisitUtil;
 import org.smartregister.chw.hf.R;
@@ -69,6 +70,9 @@ import androidx.recyclerview.widget.RecyclerView;
 import timber.log.Timber;
 
 import static org.smartregister.chw.core.utils.CoreConstants.EventType.PMTCT_COMMUNITY_FOLLOWUP;
+import static org.smartregister.chw.hf.utils.Constants.JsonFormConstants.STEP1;
+import static org.smartregister.util.JsonFormUtils.FIELDS;
+import static org.smartregister.util.JsonFormUtils.VALUE;
 
 public class PmtctProfileActivity extends CorePmtctProfileActivity {
     private static String baseEntityId;
@@ -130,6 +134,15 @@ public class PmtctProfileActivity extends CorePmtctProfileActivity {
                 return true;
             } else if (itemId == R.id.action_issue_pmtct_followup_referral) {
                 JSONObject formJsonObject = (new FormUtils()).getFormJsonFromRepositoryOrAssets(this, CoreConstants.JSON_FORM.getPmtctcCommunityFollowupReferral());
+
+                Date lastVisitDate;
+                if (followUpVisitDate != null) {
+                    lastVisitDate = followUpVisitDate;
+                } else {
+                    lastVisitDate = pmtctRegisterDate;
+                }
+                CoreJsonFormUtils.getJsonField(formJsonObject, STEP1, "last_client_visit_date").put(VALUE, sdf.format(lastVisitDate));
+
                 startFormActivity(formJsonObject);
                 return true;
             }
@@ -299,11 +312,11 @@ public class PmtctProfileActivity extends CorePmtctProfileActivity {
             try {
                 formJsonObject = (new FormUtils()).getFormJsonFromRepositoryOrAssets(this, org.smartregister.chw.hf.utils.Constants.JsonForm.getEacVisitsForm());
                 if (formJsonObject != null) {
-                    JSONArray fields = formJsonObject.getJSONObject(org.smartregister.chw.hf.utils.Constants.JsonFormConstants.STEP1).getJSONArray(JsonFormConstants.FIELDS);
+                    JSONArray fields = formJsonObject.getJSONObject(STEP1).getJSONArray(JsonFormConstants.FIELDS);
                     JSONObject visit_type = org.smartregister.util.JsonFormUtils.getFieldJSONObject(fields, "eac_visit_type");
 
                     assert visit_type != null;
-                    visit_type.put(JsonFormUtils.VALUE, HfPmtctDao.getEacVisitType(baseEntityId));
+                    visit_type.put(VALUE, HfPmtctDao.getEacVisitType(baseEntityId));
 
                     startFormActivity(formJsonObject);
                 }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/activity/PmtctProfileActivity.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/activity/PmtctProfileActivity.java
@@ -74,10 +74,6 @@ import timber.log.Timber;
 import static org.smartregister.AllConstants.LocationConstants.SPECIAL_TAG_FOR_OPENMRS_TEAM_MEMBERS;
 import static org.smartregister.chw.core.utils.CoreConstants.EventType.PMTCT_COMMUNITY_FOLLOWUP;
 import static org.smartregister.chw.hf.utils.Constants.JsonFormConstants.STEP1;
-import static org.smartregister.chw.hf.utils.JsonFormUtils.METADATA;
-import static org.smartregister.chw.hf.utils.JsonFormUtils.SYNC_LOCATION_ID;
-import static org.smartregister.util.JsonFormUtils.ENCOUNTER_LOCATION;
-import static org.smartregister.util.JsonFormUtils.FIELDS;
 import static org.smartregister.util.JsonFormUtils.VALUE;
 
 public class PmtctProfileActivity extends CorePmtctProfileActivity {

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/PmtctProfileInteractor.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/PmtctProfileInteractor.java
@@ -1,8 +1,5 @@
 package org.smartregister.chw.hf.interactor;
 
-import static org.smartregister.client.utils.constants.JsonFormConstants.STEP1;
-import static org.smartregister.client.utils.constants.JsonFormConstants.VALUE;
-
 import org.json.JSONObject;
 import org.smartregister.chw.anc.util.JsonFormUtils;
 import org.smartregister.chw.anc.util.NCUtils;
@@ -17,21 +14,26 @@ import org.smartregister.repository.AllSharedPreferences;
 
 import timber.log.Timber;
 
+import static org.smartregister.client.utils.constants.JsonFormConstants.STEP1;
+import static org.smartregister.client.utils.constants.JsonFormConstants.VALUE;
+
 public class PmtctProfileInteractor extends CorePmtctProfileInteractor {
     public void createPmtctCommunityFollowupReferralEvent(AllSharedPreferences allSharedPreferences, String jsonString, String entityID) {
         Event baseEvent = JsonFormUtils.processJsonForm(allSharedPreferences, CoreReferralUtils.setEntityId(jsonString, entityID), CoreConstants.TABLE_NAME.PMTCT_COMMUNITY_FOLLOWUP);
         JsonFormUtils.tagEvent(allSharedPreferences, baseEvent);
-        String syncLocationId = ChwNotificationDao.getSyncLocationId(baseEvent.getBaseEntityId());
-        if (syncLocationId != null) {
-            // Allows setting the ID for sync purposes
-            baseEvent.setLocationId(syncLocationId);
-        }
 
         try {
             JSONObject reasonsForIssuingCommunityReferral = CoreJsonFormUtils.getJsonField(new JSONObject(jsonString), STEP1, "reasons_for_issuing_community_referral");
+            JSONObject motherChampionLocation = CoreJsonFormUtils.getJsonField(new JSONObject(jsonString), STEP1, "mother_champion_location");
             if (reasonsForIssuingCommunityReferral.getString(VALUE).equals("mother_champion_services")) {
                 //Updating the event type to Mother Champion Referral
                 baseEvent.setEventType(Constants.Events.MOTHER_CHAMPION_COMMUNITY_SERVICES_REFERRAL);
+            }
+            //update sync location to send the referral to the correct targeted chw,
+            // this is needed for the case of global search client who have moved or clients that may have moved village
+            if(motherChampionLocation != null){
+                String locationId = CoreJsonFormUtils.getSyncLocationUUIDFromDropdown(motherChampionLocation);
+                baseEvent.setLocationId(locationId);
             }
         } catch (Exception e) {
             Timber.e(e);

--- a/opensrp-chw-hf/src/main/res/menu/pmtct_profile_menu.xml
+++ b/opensrp-chw-hf/src/main/res/menu/pmtct_profile_menu.xml
@@ -11,7 +11,7 @@
     <item
         android:id="@+id/action_issue_pmtct_followup_referral"
         android:enabled="true"
-        android:title="@string/issue_pmtct_community_followup_referral"
+        android:title="@string/mother_champion_referral"
         app:showAsAction="never" />
 
     <item

--- a/opensrp-chw-hf/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw-hf/src/main/res/values-sw/strings.xml
@@ -225,6 +225,7 @@
     <string name="no_mother_children">Watoto wasio na mama</string>
     <string name="no_mother_child_reg">Usajili wa mtoto asiye na mama</string>
     <string name="register_child">Sajili Mtoto</string>
+    <string name="mother_champion_referral">Rufaa kwa Mama Kinara </string>
 
     <!-- HEI Medical History -->
     <string name="hei_visit_title">Hudhurio la HEI {0}: {1}, Umri {2}</string>

--- a/opensrp-chw-hf/src/main/res/values/strings.xml
+++ b/opensrp-chw-hf/src/main/res/values/strings.xml
@@ -374,6 +374,7 @@
     <string name="community_ltfu_summary_subtitle">View Report Summary for LTFU</string>
     <string name="ld_reports_subtitle">View Labour Delivery Reports</string>
     <string name="ld_report_title">Labour And Delivery Reports</string>
+    <string name="mother_champion_referral">Mother Champion Referral</string>
 
 
 </resources>


### PR DESCRIPTION
- [x] Rename the titles for the referral to Mother champion referral to distinguish it from the LTFU Referral
- [x]  Allows the user to edit the last facility visit when issuing the mother champion referral
- [x]  Updated the referral form to allow setting the mother champion location from dropdown to allow the clients that may have been brought through via global search or clients who have moved villages