### PR TITLE
Capture malaria test

### DIFF
--- a/opensrp-chw-hf/src/main/assets/ec_client_fields.json
+++ b/opensrp-chw-hf/src/main/assets/ec_client_fields.json
@@ -5328,6 +5328,14 @@
           }
         },
         {
+          "column_name": "syphilis",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.formSubmissionField",
+            "concept": "syphilis"
+          }
+        },
+        {
           "column_name": "last_interacted_with",
           "type": "Event",
           "json_mapping": {

--- a/opensrp-chw-hf/src/main/assets/ec_client_fields.json
+++ b/opensrp-chw-hf/src/main/assets/ec_client_fields.json
@@ -5336,6 +5336,14 @@
           }
         },
         {
+          "column_name": "malaria",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.formSubmissionField",
+            "concept": "malaria"
+          }
+        },
+        {
           "column_name": "last_interacted_with",
           "type": "Event",
           "json_mapping": {

--- a/opensrp-chw-hf/src/main/assets/json.form/labour_and_delivery_malaria_test.json
+++ b/opensrp-chw-hf/src/main/assets/json.form/labour_and_delivery_malaria_test.json
@@ -1,0 +1,125 @@
+{
+  "count": "1",
+  "skip_blank_steps": true,
+  "encounter_type": "Labour and Delivery Malaria Test",
+  "entity_id": "",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": ""
+  },
+  "step1": {
+    "title": "Malaria Test",
+    "fields": [
+      {
+        "key": "malaria_test",
+        "type": "native_radio",
+        "label": "Malaria test results",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "syphilis",
+        "openmrs_entity_parent": "",
+        "options": [
+          {
+            "key": "positive",
+            "text": "Positive",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "positive"
+          },
+          {
+            "key": "negative",
+            "text": "Negative",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "negative"
+          },
+          {
+            "key": "test_not_conducted",
+            "text": "Test not conducted",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "test_not_conducted"
+          }
+        ]
+      },
+      {
+        "key": "management_provided_for_malaria",
+        "type": "native_radio",
+        "label": "Was management provided for malaria?",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "management_provided_for_malaria",
+        "openmrs_entity_parent": "",
+        "options": [
+          {
+            "key": "yes",
+            "text": "Yes",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "yes"
+          },
+          {
+            "key": "no",
+            "text": "No",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "no"
+          }
+        ],
+        "v_required": {
+          "value": "true",
+          "err": "Please answer this question"
+        },
+        "relevance": {
+          "step1:malaria_test": {
+            "type": "string",
+            "ex": "equalTo(., \"positive\")"
+          }
+        }
+      },
+      {
+        "key": "prompt_for_malaria_management_not_done",
+        "type": "toaster_notes",
+        "text": "Provide management according to SOP and Standard Guideline",
+        "openmrs_entity_id": "",
+        "openmrs_entity": "",
+        "openmrs_entity_parent": "",
+        "toaster_type": "problem",
+        "relevance": {
+          "step1:management_provided_for_malaria": {
+            "type": "string",
+            "ex": "equalTo(., \"no\")"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/opensrp-chw-hf/src/main/assets/json.form/labour_and_delivery_registration_anc_clinic_findings.json
+++ b/opensrp-chw-hf/src/main/assets/json.form/labour_and_delivery_registration_anc_clinic_findings.json
@@ -416,10 +416,10 @@
             "openmrs_entity_id": "negative"
           },
           {
-            "key": "none",
-            "text": "None",
+            "key": "test_not_conducted",
+            "text": "Not conducted",
             "openmrs_entity": "concept",
-            "openmrs_entity_id": "none"
+            "openmrs_entity_id": "test_not_conducted"
           }
         ]
       },

--- a/opensrp-chw-hf/src/main/assets/json.form/labour_and_delivery_syphilis_test.json
+++ b/opensrp-chw-hf/src/main/assets/json.form/labour_and_delivery_syphilis_test.json
@@ -1,0 +1,125 @@
+{
+  "count": "1",
+  "skip_blank_steps": true,
+  "encounter_type": "Labour and Delivery Syphilis Test",
+  "entity_id": "",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": ""
+  },
+  "step1": {
+    "title": "Syphilis Test",
+    "fields": [
+      {
+        "key": "syphilis",
+        "type": "native_radio",
+        "label": "VDRL (Syphilis)",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "syphilis",
+        "openmrs_entity_parent": "",
+        "options": [
+          {
+            "key": "positive",
+            "text": "Positive",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "positive"
+          },
+          {
+            "key": "negative",
+            "text": "Negative",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "negative"
+          },
+          {
+            "key": "none",
+            "text": "None",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "none"
+          }
+        ]
+      },
+      {
+        "key": "management_provided_for_syphilis",
+        "type": "native_radio",
+        "label": "Was management provided for syphilis?",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "management_provided_for_syphilis",
+        "openmrs_entity_parent": "",
+        "options": [
+          {
+            "key": "yes",
+            "text": "Yes",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "yes"
+          },
+          {
+            "key": "no",
+            "text": "No",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "no"
+          }
+        ],
+        "v_required": {
+          "value": "true",
+          "err": "Please answer this question"
+        },
+        "relevance": {
+          "step1:syphilis": {
+            "type": "string",
+            "ex": "equalTo(., \"positive\")"
+          }
+        }
+      },
+      {
+        "key": "prompt_for_syphilis_management_not_done",
+        "type": "toaster_notes",
+        "text": "Provide management according to SOP and Standard Guideline",
+        "openmrs_entity_id": "",
+        "openmrs_entity": "",
+        "openmrs_entity_parent": "",
+        "toaster_type": "problem",
+        "relevance": {
+          "step1:management_provided_for_syphilis": {
+            "type": "string",
+            "ex": "equalTo(., \"no\")"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDMalariaTestActionHelper.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDMalariaTestActionHelper.java
@@ -27,7 +27,7 @@ public class LDMalariaTestActionHelper implements BaseLDVisitAction.LDVisitActio
 
     @Override
     public void onJsonFormLoaded(String s, Context context, Map<String, List<VisitDetail>> map) {
-
+        //TODO: implement
     }
 
     @Override
@@ -79,6 +79,6 @@ public class LDMalariaTestActionHelper implements BaseLDVisitAction.LDVisitActio
 
     @Override
     public void onPayloadReceived(BaseLDVisitAction baseLDVisitAction) {
-
+        //TODO: implement
     }
 }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDMalariaTestActionHelper.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDMalariaTestActionHelper.java
@@ -1,0 +1,84 @@
+package org.smartregister.chw.hf.actionhelper;
+
+import android.content.Context;
+
+import org.smartregister.chw.hf.R;
+import org.smartregister.chw.hf.utils.JsonFormUtils;
+import org.smartregister.chw.ld.domain.VisitDetail;
+import org.smartregister.chw.ld.model.BaseLDVisitAction;
+
+import java.util.List;
+import java.util.Map;
+
+import timber.log.Timber;
+
+/**
+ * Author issyzac on 2022-07-13
+ */
+
+public class LDMalariaTestActionHelper implements BaseLDVisitAction.LDVisitActionHelper {
+
+    private final Context context;
+    private String malariaTest;
+
+    public LDMalariaTestActionHelper(Context context){
+        this.context = context;
+    }
+
+    @Override
+    public void onJsonFormLoaded(String s, Context context, Map<String, List<VisitDetail>> map) {
+
+    }
+
+    @Override
+    public String getPreProcessed() {
+        return null;
+    }
+
+    @Override
+    public void onPayloadReceived(String jsonPayload) {
+        try{
+            malariaTest = JsonFormUtils.getFieldValue(jsonPayload, "malaria_test");
+        }catch (Exception e){
+            Timber.e(e);
+        }
+    }
+
+    @Override
+    public BaseLDVisitAction.ScheduleStatus getPreProcessedStatus() {
+        return null;
+    }
+
+    @Override
+    public String getPreProcessedSubTitle() {
+        return null;
+    }
+
+    @Override
+    public String postProcess(String s) {
+        return null;
+    }
+
+    @Override
+    public String evaluateSubTitle() {
+        String subtitle = "";
+        if (malariaTest != null && !malariaTest.isEmpty()){
+            subtitle = context.getString(R.string.syphilis_test_result) + ": " + malariaTest;
+        }
+        return subtitle;
+    }
+
+    @Override
+    public BaseLDVisitAction.Status evaluateStatusOnPayload() {
+        if (malariaTest != null && !malariaTest.isEmpty()){
+            return BaseLDVisitAction.Status.COMPLETED;
+        }else{
+            return BaseLDVisitAction.Status.PENDING;
+        }
+    }
+
+    @Override
+    public void onPayloadReceived(BaseLDVisitAction baseLDVisitAction) {
+
+    }
+}

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDSyphilisTestActionHelper.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDSyphilisTestActionHelper.java
@@ -1,0 +1,86 @@
+package org.smartregister.chw.hf.actionhelper;
+
+import android.content.Context;
+
+import org.json.JSONObject;
+import org.smartregister.chw.hf.R;
+import org.smartregister.chw.hf.utils.JsonFormUtils;
+import org.smartregister.chw.ld.domain.VisitDetail;
+import org.smartregister.chw.ld.model.BaseLDVisitAction;
+
+import java.sql.Struct;
+import java.util.List;
+import java.util.Map;
+
+import timber.log.Timber;
+
+/**
+ * Author issyzac on 2022-07-13
+ */
+
+public class LDSyphilisTestActionHelper implements BaseLDVisitAction.LDVisitActionHelper {
+
+    private final Context context;
+    private String syphilisTest;
+
+    public LDSyphilisTestActionHelper(Context context){
+        this.context = context;
+    }
+
+    @Override
+    public void onJsonFormLoaded(String s, Context context, Map<String, List<VisitDetail>> map) {
+
+    }
+
+    @Override
+    public String getPreProcessed() {
+        return null;
+    }
+
+    @Override
+    public void onPayloadReceived(String jsonPayload) {
+        try{
+            syphilisTest = JsonFormUtils.getFieldValue(jsonPayload, "syphilis");
+        }catch (Exception e){
+            Timber.e(e);
+        }
+    }
+
+    @Override
+    public BaseLDVisitAction.ScheduleStatus getPreProcessedStatus() {
+        return null;
+    }
+
+    @Override
+    public String getPreProcessedSubTitle() {
+        return null;
+    }
+
+    @Override
+    public String postProcess(String s) {
+        return null;
+    }
+
+    @Override
+    public String evaluateSubTitle() {
+        String subtitle = "";
+        if (syphilisTest != null && !syphilisTest.isEmpty()){
+            subtitle = context.getString(R.string.syphilis_test_result) + ": " + syphilisTest;
+        }
+        return subtitle;
+    }
+
+    @Override
+    public BaseLDVisitAction.Status evaluateStatusOnPayload() {
+        if (syphilisTest != null && !syphilisTest.isEmpty()){
+            return BaseLDVisitAction.Status.COMPLETED;
+        }else{
+            return BaseLDVisitAction.Status.PENDING;
+        }
+    }
+
+    @Override
+    public void onPayloadReceived(BaseLDVisitAction baseLDVisitAction) {
+
+    }
+}

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDSyphilisTestActionHelper.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDSyphilisTestActionHelper.java
@@ -2,13 +2,11 @@ package org.smartregister.chw.hf.actionhelper;
 
 import android.content.Context;
 
-import org.json.JSONObject;
 import org.smartregister.chw.hf.R;
 import org.smartregister.chw.hf.utils.JsonFormUtils;
 import org.smartregister.chw.ld.domain.VisitDetail;
 import org.smartregister.chw.ld.model.BaseLDVisitAction;
 
-import java.sql.Struct;
 import java.util.List;
 import java.util.Map;
 

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDSyphilisTestActionHelper.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/actionhelper/LDSyphilisTestActionHelper.java
@@ -27,7 +27,7 @@ public class LDSyphilisTestActionHelper implements BaseLDVisitAction.LDVisitActi
 
     @Override
     public void onJsonFormLoaded(String s, Context context, Map<String, List<VisitDetail>> map) {
-
+        //TODO: implement
     }
 
     @Override
@@ -79,6 +79,6 @@ public class LDSyphilisTestActionHelper implements BaseLDVisitAction.LDVisitActi
 
     @Override
     public void onPayloadReceived(BaseLDVisitAction baseLDVisitAction) {
-
+        //TODO: implement
     }
 }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/dao/LDDao.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/dao/LDDao.java
@@ -183,4 +183,15 @@ public class LDDao extends org.smartregister.chw.ld.dao.LDDao {
         return null;
     }
 
+    public static String getMalariaTest(String baseEntityId) {
+        String sql = "SELECT malaria FROM " + Constants.TABLES.LD_CONFIRMATION + " WHERE base_entity_id = '" + baseEntityId + "'";
+
+        DataMap<String> dataMap = cursor -> getCursorValue(cursor, "malaria");
+
+        List<String> res = readData(sql, dataMap);
+        if (res != null && res.size() > 0)
+            return res.get(0);
+        return null;
+    }
+
 }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/dao/LDDao.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/dao/LDDao.java
@@ -172,4 +172,15 @@ public class LDDao extends org.smartregister.chw.ld.dao.LDDao {
         return null;
     }
 
+    public static String getSyphilisTest(String baseEntityId) {
+        String sql = "SELECT syphilis FROM " + Constants.TABLES.LD_CONFIRMATION + " WHERE base_entity_id = '" + baseEntityId + "'";
+
+        DataMap<String> dataMap = cursor -> getCursorValue(cursor, "syphilis");
+
+        List<String> res = readData(sql, dataMap);
+        if (res != null && res.size() > 0)
+            return res.get(0);
+        return null;
+    }
+
 }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
@@ -83,6 +83,8 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
 
                 evaluateSyphilisTest(details);
 
+                evaluateMalariatest(details);
+
             } catch (BaseLDVisitAction.ValidationException e) {
                 Timber.e(e);
             }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
@@ -10,6 +10,7 @@ import org.smartregister.chw.hf.R;
 import org.smartregister.chw.hf.actionhelper.LDHBTestActionHelper;
 import org.smartregister.chw.hf.actionhelper.LDHIVTestActionHelper;
 import org.smartregister.chw.hf.actionhelper.LDGeneralExaminationActionHelper;
+import org.smartregister.chw.hf.actionhelper.LDMalariaTestActionHelper;
 import org.smartregister.chw.hf.actionhelper.LDSyphilisTestActionHelper;
 import org.smartregister.chw.hf.actionhelper.LDVaginalExaminationActionHelper;
 import org.smartregister.chw.hf.dao.LDDao;
@@ -144,7 +145,7 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
 
         String title = context.getString(R.string.lb_visit_malaria_test_status_action_title);
 
-        LDSyphilisTestActionHelper actionHelper = new LDSyphilisTestActionHelper(context);
+        LDMalariaTestActionHelper actionHelper = new LDMalariaTestActionHelper(context);
         BaseLDVisitAction action = getBuilder(title)
                 .withOptional(false)
                 .withHelper(actionHelper)

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
@@ -2,9 +2,6 @@ package org.smartregister.chw.hf.interactor;
 
 import android.content.Context;
 
-import com.google.android.gms.vision.L;
-
-import org.apache.commons.lang3.time.DateUtils;
 import org.smartregister.chw.anc.util.VisitUtils;
 import org.smartregister.chw.hf.R;
 import org.smartregister.chw.hf.actionhelper.LDHBTestActionHelper;

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
@@ -81,7 +81,8 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
                     evaluateHBTest(details);
                 }
 
-                evaluateSyphilisTest(details);
+                if (!syphilisTestConductedDuringRegistration())
+                    evaluateSyphilisTest(details);
 
             } catch (BaseLDVisitAction.ValidationException e) {
                 Timber.e(e);
@@ -91,6 +92,14 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
         };
 
         appExecutors.diskIO().execute(runnable);
+    }
+
+    private boolean syphilisTestConductedDuringRegistration(){
+        if (LDDao.getSyphilisTest(memberObject.getBaseEntityId()) != null){
+            String syphilisTestDate = LDDao.getSyphilisTest(memberObject.getBaseEntityId());
+            return !syphilisTestDate.equalsIgnoreCase(Constants.FormConstants.ClinicFindings.Syphilis.SYPHILIS_TEST_NOT_DONE);
+        }
+        return false;
     }
 
     private boolean hbTestMoreThanTwoWeeksAgo() {

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
@@ -10,6 +10,7 @@ import org.smartregister.chw.hf.R;
 import org.smartregister.chw.hf.actionhelper.LDHBTestActionHelper;
 import org.smartregister.chw.hf.actionhelper.LDHIVTestActionHelper;
 import org.smartregister.chw.hf.actionhelper.LDGeneralExaminationActionHelper;
+import org.smartregister.chw.hf.actionhelper.LDSyphilisTestActionHelper;
 import org.smartregister.chw.hf.actionhelper.LDVaginalExaminationActionHelper;
 import org.smartregister.chw.hf.dao.LDDao;
 import org.smartregister.chw.hf.utils.Constants;
@@ -80,6 +81,8 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
                     evaluateHBTest(details);
                 }
 
+                evaluateSyphilisTest(details);
+
             } catch (BaseLDVisitAction.ValidationException e) {
                 Timber.e(e);
             }
@@ -133,6 +136,21 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
             }
         }
         return true;
+    }
+
+    private void evaluateSyphilisTest(Map<String, List<VisitDetail>> details) throws BaseLDVisitAction.ValidationException {
+
+        String title = context.getString(R.string.lb_visit_syphilis_test_status_action_title);
+
+        LDSyphilisTestActionHelper actionHelper = new LDSyphilisTestActionHelper(context);
+        BaseLDVisitAction action = getBuilder(title)
+                .withOptional(false)
+                .withHelper(actionHelper)
+                .withDetails(details)
+                .withFormName(Constants.JsonForm.LDVisit.getSyphilisTestForm())
+                .build();
+
+        actionList.put(title, action);
     }
 
     private void evaluateHIVStatus(Map<String, List<VisitDetail>> details) throws BaseLDVisitAction.ValidationException {

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
@@ -77,7 +77,6 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
                     evaluateHIVStatus(details);
                 }
 
-                //Todo: add HB Test if last_hb_test is more than 2 weeks ago
                 if (hbTestMoreThanTwoWeeksAgo()){
                     evaluateHBTest(details);
                 }
@@ -85,7 +84,8 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
                 if (!syphilisTestConductedDuringRegistration())
                     evaluateSyphilisTest(details);
 
-                evaluateMalariatest(details);
+                if (!malariaTestConductedDuringRegistration())
+                    evaluateMalariatest(details);
 
             } catch (BaseLDVisitAction.ValidationException e) {
                 Timber.e(e);
@@ -97,10 +97,18 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
         appExecutors.diskIO().execute(runnable);
     }
 
+    private boolean malariaTestConductedDuringRegistration(){
+        if (LDDao.getMalariaTest(memberObject.getBaseEntityId()) != null){
+            String malariaTest = LDDao.getMalariaTest(memberObject.getBaseEntityId());
+            return !malariaTest.equalsIgnoreCase(Constants.FormConstants.ClinicFindings.Malaria.MALARIA_TEST_NOT_DONE);
+        }
+        return false;
+    }
+
     private boolean syphilisTestConductedDuringRegistration(){
         if (LDDao.getSyphilisTest(memberObject.getBaseEntityId()) != null){
-            String syphilisTestDate = LDDao.getSyphilisTest(memberObject.getBaseEntityId());
-            return !syphilisTestDate.equalsIgnoreCase(Constants.FormConstants.ClinicFindings.Syphilis.SYPHILIS_TEST_NOT_DONE);
+            String syphilisTest = LDDao.getSyphilisTest(memberObject.getBaseEntityId());
+            return !syphilisTest.equalsIgnoreCase(Constants.FormConstants.ClinicFindings.Syphilis.SYPHILIS_TEST_NOT_DONE);
         }
         return false;
     }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/interactor/LDVisitInteractor.java
@@ -138,6 +138,21 @@ public class LDVisitInteractor extends BaseLDVisitInteractor {
         return true;
     }
 
+    private void evaluateMalariatest(Map<String, List<VisitDetail>> details) throws BaseLDVisitAction.ValidationException {
+
+        String title = context.getString(R.string.lb_visit_malaria_test_status_action_title);
+
+        LDSyphilisTestActionHelper actionHelper = new LDSyphilisTestActionHelper(context);
+        BaseLDVisitAction action = getBuilder(title)
+                .withOptional(false)
+                .withHelper(actionHelper)
+                .withDetails(details)
+                .withFormName(Constants.JsonForm.LDVisit.getLdMalariaTestForm())
+                .build();
+
+        actionList.put(title, action);
+    }
+
     private void evaluateSyphilisTest(Map<String, List<VisitDetail>> details) throws BaseLDVisitAction.ValidationException {
 
         String title = context.getString(R.string.lb_visit_syphilis_test_status_action_title);

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/Constants.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/Constants.java
@@ -510,6 +510,7 @@ public class Constants extends CoreConstants {
             public static final String LD_HIV_TEST = "labour_and_delivery_hiv_test";
             public static final String LD_HB_TEST_FORM = "labour_and_delivery_hb_test_form";
             public static final String LD_SYPHILIS_TEST_FORM = "labour_and_delivery_syphilis_test";
+            public static final String LD_MALARIA_TEST_FORM = "labour_and_delivery_malaria_test";
 
             public static String getLdGeneralExamination() {
                 return Utils.getLocalForm(LD_GENERAL_EXAMINATION);
@@ -529,6 +530,10 @@ public class Constants extends CoreConstants {
 
             public static String getSyphilisTestForm() {
                 return Utils.getLocalForm(LD_SYPHILIS_TEST_FORM);
+            }
+
+            public static String getLdMalariaTestForm() {
+                return Utils.getLocalForm(LD_MALARIA_TEST_FORM);
             }
 
         }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/Constants.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/Constants.java
@@ -645,12 +645,17 @@ public class Constants extends CoreConstants {
 
         public interface ClinicFindings{
 
-            public interface Syphilis {
+            interface Syphilis {
                 String SYPHILIS_RESULT_POSITIVE = "positive";
                 String SYPHILIS_RESULT_NEGATIVE = "negative";
                 String SYPHILIS_TEST_NOT_DONE = "test_not_conducted";
             }
 
+            interface Malaria {
+                String MALARIA_RESULT_POSITIVE = "positive";
+                String MALARIA_RESULT_NEGATIVE = "negative";
+                String MALARIA_TEST_NOT_DONE = "test_not_conducted";
+            }
         }
 
     }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/Constants.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/Constants.java
@@ -509,6 +509,7 @@ public class Constants extends CoreConstants {
             public static final String LD_VAGINAL_EXAMINATION = "labour_and_delivery_vaginal_examination";
             public static final String LD_HIV_TEST = "labour_and_delivery_hiv_test";
             public static final String LD_HB_TEST_FORM = "labour_and_delivery_hb_test_form";
+            public static final String LD_SYPHILIS_TEST_FORM = "labour_and_delivery_syphilis_test";
 
             public static String getLdGeneralExamination() {
                 return Utils.getLocalForm(LD_GENERAL_EXAMINATION);
@@ -524,6 +525,10 @@ public class Constants extends CoreConstants {
 
             public static String getLdHBTestForm() {
                 return Utils.getLocalForm(LD_HB_TEST_FORM);
+            }
+
+            public static String getSyphilisTestForm() {
+                return Utils.getLocalForm(LD_SYPHILIS_TEST_FORM);
             }
 
         }

--- a/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/Constants.java
+++ b/opensrp-chw-hf/src/main/java/org/smartregister/chw/hf/utils/Constants.java
@@ -631,11 +631,23 @@ public class Constants extends CoreConstants {
     }
 
     public static final class FormConstants {
+
         public interface FormSubmissionFields {
             String VISIT_NUMBER = "visit_number";
             String FOLLOWUP_VISIT_DATE = "followup_visit_date";
             String FOLLOWUP_STATUS = "followup_status";
         }
+
+        public interface ClinicFindings{
+
+            public interface Syphilis {
+                String SYPHILIS_RESULT_POSITIVE = "positive";
+                String SYPHILIS_RESULT_NEGATIVE = "negative";
+                String SYPHILIS_TEST_NOT_DONE = "test_not_conducted";
+            }
+
+        }
+
     }
 
     public static final class ReportConstants {

--- a/opensrp-chw-hf/src/main/res/values/strings.xml
+++ b/opensrp-chw-hf/src/main/res/values/strings.xml
@@ -308,6 +308,7 @@
     <string name="lb_visit_vaginal_assessment">Vaginal assessment</string>
     <string name="lb_visit_general_examination">General examination</string>
     <string name="lb_visit_hiv_test_status_action_title">HIV Counselling and Testing</string>
+    <string name="lb_visit_syphilis_test_status_action_title">Syphilis Testing and Counselling</string>
     <string name="lb_mode_of_delivery">Mode of Delivery</string>
     <string name="ld_active_management_3rd_stage">Active Management of 3rd Stage</string>
     <string name="uterotonic">Uterotonic</string>
@@ -408,5 +409,7 @@
 
     <string name="lb_visit_hb_test_action_title"> HB test </string>
     <string name="referred_for_ld_emergency">Referred</string>
+
+    <string name="syphilis_test_result"> Syphilis test </string>
 
 </resources>

--- a/opensrp-chw-hf/src/main/res/values/strings.xml
+++ b/opensrp-chw-hf/src/main/res/values/strings.xml
@@ -308,6 +308,7 @@
     <string name="lb_visit_vaginal_assessment">Vaginal assessment</string>
     <string name="lb_visit_general_examination">General examination</string>
     <string name="lb_visit_hiv_test_status_action_title">HIV Counselling and Testing</string>
+    <string name="lb_visit_malaria_test_status_action_title">Malaria</string>
     <string name="lb_visit_syphilis_test_status_action_title">Syphilis Testing and Counselling</string>
     <string name="lb_mode_of_delivery">Mode of Delivery</string>
     <string name="ld_active_management_3rd_stage">Active Management of 3rd Stage</string>


### PR DESCRIPTION
Closes #343 

- [x] Capture results for malaria test
- [x] if positive result add follow up option to provide management for malaria
- [x] If the question for management provided is No, then a prompt has to be shown with content sales as the one on the RH question
- [x] Add condition to only show the test if it was not conducted during the registration process